### PR TITLE
[dev] #27 현재 사용자의 위치에서 화장실이 얼마나 떨어져 있는지 거리 표시

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
         <Script
           type='text/javascript'
           src={`https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${process.env.NEXT_PUBLIC_NAVER_MAP_API_KEY}&submodules=geocoder,panorama`}
+          strategy='beforeInteractive'
         />
         <Script src='/MarkerClustering.js' />
       </body>

--- a/src/app/map/error.tsx
+++ b/src/app/map/error.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className='flex min-h-screen w-full flex-col break-keep bg-white'>
+      <section className='flex flex-1 flex-col items-center justify-center bg-blue-50 px-4 py-28 text-center sm:px-6 lg:px-8'>
+        <h1 className='mb-4 text-4xl font-bold text-blue-500 sm:text-5xl'>오류</h1>
+        <p className='mb-8 text-base text-gray-700 sm:text-lg'>
+          오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
+        </p>
+        <button
+          onClick={reset}
+          className='rounded-md bg-blue-500 px-6 py-3 text-base font-semibold text-white shadow-md hover:bg-blue-600'
+        >
+          다시 시도하기
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -133,7 +133,7 @@ export default function Map({ toilets }: MapProps) {
     // 마커와 정보창
     const toiletMarkers: naver.maps.Marker[] = [];
     toiletsWithDistance.forEach((toilet) => {
-      const { Y_WGS84, X_WGS84, FNAME, ANAME } = toilet;
+      const { Y_WGS84, X_WGS84, FNAME, ANAME, DISTANCE } = toilet;
 
       const marker = new naver.maps.Marker({
         position: new naver.maps.LatLng(Y_WGS84, X_WGS84),
@@ -171,6 +171,7 @@ export default function Map({ toilets }: MapProps) {
             (status, response) => {
               if (status === naver.maps.Service.Status.OK && mapRef.current) {
                 const { jibunAddress, roadAddress } = response.v2.address;
+
                 flushSync(() =>
                   root.render(
                     <MarkerInfoWindow
@@ -178,6 +179,7 @@ export default function Map({ toilets }: MapProps) {
                       ANAME={ANAME}
                       jibunAddress={jibunAddress}
                       roadAddress={roadAddress}
+                      DISTANCE={DISTANCE}
                       onClickPanorama={() => {
                         handleOpenPanorama(Y_WGS84, X_WGS84);
                         if (mapRef.current) mapRef.current.panTo(coords);

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -91,30 +91,46 @@ export default function Map({ toilets }: MapProps) {
   const currentLocationMarkerRef = useRef<naver.maps.Marker | null>(null);
   const panoramaRef = useRef<HTMLDivElement | null>(null);
   const addressInputRef = useRef<HTMLInputElement | null>(null);
-  const hasInitialized = useRef<boolean>(false);
 
   const { currentMyCoordinates, geoStatus, getCurPosition } = useGeolocation();
+
+  // const toiletsWithDistance = useMemo(() => {
+  //   if (!currentMyCoordinates) return toilets;
+
+  //   return toilets.map((toilet) => ({
+  //     ...toilet,
+  //     DISTANCE: distanceCalculation(
+  //       currentMyCoordinates.lat,
+  //       currentMyCoordinates.lng,
+  //       toilet.Y_WGS84,
+  //       toilet.X_WGS84,
+  //       'K',
+  //     ),
+  //   }));
+  // }, [toilets, currentMyCoordinates]);
 
   const toiletsWithDistance = useMemo(() => {
     if (!currentMyCoordinates) return toilets;
 
-    return toilets.map((toilet) => ({
-      ...toilet,
-      DISTANCE: distanceCalculation(
-        currentMyCoordinates.lat,
-        currentMyCoordinates.lng,
-        toilet.Y_WGS84,
-        toilet.X_WGS84,
-        'K',
-      ),
-    }));
+    return toilets
+      .map((toilet) => ({
+        ...toilet,
+        DISTANCE: distanceCalculation(
+          currentMyCoordinates.lat,
+          currentMyCoordinates.lng,
+          toilet.Y_WGS84,
+          toilet.X_WGS84,
+          'K',
+        ),
+      }))
+      .sort((a, b) => a.DISTANCE - b.DISTANCE)
+      .slice(0, 100);
   }, [toilets, currentMyCoordinates]);
 
-  // 지도 초기화 + 마커 렌더링 + 클러스터링
+  // 지도 초기화
   useEffect(() => {
-    if (!currentMyCoordinates || hasInitialized.current) return;
+    if (!currentMyCoordinates || mapRef.current) return;
 
-    // 지도
     mapRef.current = new naver.maps.Map('map', {
       center: new naver.maps.LatLng(currentMyCoordinates.lat, currentMyCoordinates.lng),
       zoom: 18,
@@ -122,6 +138,11 @@ export default function Map({ toilets }: MapProps) {
       mapDataControl: false,
       disableKineticPan: false,
     });
+  }, [currentMyCoordinates]);
+
+  // 마커 렌더링 + 클러스터링
+  useEffect(() => {
+    if (!mapRef.current) return;
 
     if (!toiletsWithDistance.length) {
       toast.error('화장실 데이터를 불러오는데 실패했습니다. 잠시 후 다시 시도해 주세요.', {
@@ -239,8 +260,12 @@ export default function Map({ toilets }: MapProps) {
         if (el) el.textContent = String(count);
       },
     });
+  }, [toiletsWithDistance]);
 
-    // 현재 사용자가 서울에 위치해 있는지 확인
+  useEffect(() => {
+    if (!currentMyCoordinates) return;
+
+    // 현재 좌표가 서울 경계 밖에 있는지 체크
     if (
       currentMyCoordinates.lat > seoulBoundaryCoordinates.north ||
       currentMyCoordinates.lat < seoulBoundaryCoordinates.south ||
@@ -248,14 +273,12 @@ export default function Map({ toilets }: MapProps) {
       currentMyCoordinates.lng > seoulBoundaryCoordinates.east
     ) {
       setIsOutsideSeoul(true);
+    } else {
+      setIsOutsideSeoul(false);
     }
-
-    hasInitialized.current = true;
-  }, [currentMyCoordinates, toiletsWithDistance]);
+  }, [currentMyCoordinates]);
 
   useEffect(() => {
-    if (!mapRef.current) return;
-
     if (geoStatus === 'error') {
       toast.error(
         '현재 위치 정보를 가져올 수 없습니다. 브라우저의 위치 접근 권한을 확인해 주세요.',
@@ -266,9 +289,10 @@ export default function Map({ toilets }: MapProps) {
       return;
     }
 
-    if (geoStatus !== 'success' || !currentMyCoordinates) return;
+    if (!mapRef.current || geoStatus !== 'success' || !currentMyCoordinates) return;
 
     if (currentLocationMarkerRef.current) currentLocationMarkerRef.current.setMap(null);
+
     currentLocationMarkerRef.current = new naver.maps.Marker({
       position: new naver.maps.LatLng(currentMyCoordinates.lat, currentMyCoordinates.lng),
       map: mapRef.current,
@@ -277,6 +301,7 @@ export default function Map({ toilets }: MapProps) {
         anchor: new naver.maps.Point(12, 12),
       },
     });
+
     mapRef.current.panTo(new naver.maps.LatLng(currentMyCoordinates.lat, currentMyCoordinates.lng));
   }, [currentMyCoordinates, geoStatus]);
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -6,7 +6,7 @@ import { FiPlus, FiMinus } from 'react-icons/fi';
 import { IoIosClose, IoIosAlert, IoMdLocate } from 'react-icons/io';
 
 import Image from 'next/image';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { flushSync } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { createRoot } from 'react-dom/client';
@@ -25,6 +25,7 @@ import {
 } from '@/components/Markers';
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { defalutCoordinates } from '@/hooks/useGeolocation';
+import { distanceCalculation } from '@/util/helpers/distanceCalculation';
 import { Coords } from '@/util/types';
 import normalMap from '../../public/normal-map.png';
 import terrainMap from '../../public/terrain-map.png';
@@ -94,6 +95,21 @@ export default function Map({ toilets }: MapProps) {
 
   const { currentMyCoordinates, geoStatus, getCurPosition } = useGeolocation();
 
+  const toiletsWithDistance = useMemo(() => {
+    if (!currentMyCoordinates) return toilets;
+
+    return toilets.map((toilet) => ({
+      ...toilet,
+      DISTANCE: distanceCalculation(
+        currentMyCoordinates.lat,
+        currentMyCoordinates.lng,
+        toilet.Y_WGS84,
+        toilet.X_WGS84,
+        'K',
+      ),
+    }));
+  }, [toilets, currentMyCoordinates]);
+
   // 지도 초기화 + 마커 렌더링 + 클러스터링
   useEffect(() => {
     if (!currentMyCoordinates || hasInitialized.current) return;
@@ -107,7 +123,7 @@ export default function Map({ toilets }: MapProps) {
       disableKineticPan: false,
     });
 
-    if (!toilets.length) {
+    if (!toiletsWithDistance.length) {
       toast.error('화장실 데이터를 불러오는데 실패했습니다. 잠시 후 다시 시도해 주세요.', {
         icon: <IoIosAlert className='text-blue-500' size={20} />,
       });
@@ -116,7 +132,7 @@ export default function Map({ toilets }: MapProps) {
 
     // 마커와 정보창
     const toiletMarkers: naver.maps.Marker[] = [];
-    toilets.forEach((toilet) => {
+    toiletsWithDistance.forEach((toilet) => {
       const { Y_WGS84, X_WGS84, FNAME, ANAME } = toilet;
 
       const marker = new naver.maps.Marker({
@@ -233,7 +249,7 @@ export default function Map({ toilets }: MapProps) {
     }
 
     hasInitialized.current = true;
-  }, [currentMyCoordinates, toilets]);
+  }, [currentMyCoordinates, toiletsWithDistance]);
 
   useEffect(() => {
     if (!mapRef.current) return;

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -89,9 +89,10 @@ export default function Map({ toilets }: MapProps) {
   const [mapCenterCoords, setMapCenterCoords] = useState<Coords | null>(null);
 
   const mapRef = useRef<naver.maps.Map | null>(null);
-  const markerClusterRef = useRef<any>(null);
   const currentLocationMarkerRef = useRef<naver.maps.Marker | null>(null);
+  const toiletInfoWindowsRef = useRef<naver.maps.InfoWindow[]>([]);
   const geoCoderInfowindowRef = useRef<naver.maps.InfoWindow | null>(null);
+  const markerClusterRef = useRef<any>(null);
   const panoramaRef = useRef<HTMLDivElement | null>(null);
   const addressInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -172,6 +173,7 @@ export default function Map({ toilets }: MapProps) {
         backgroundColor: 'transparent',
         borderColor: 'transparent',
       });
+      toiletInfoWindowsRef.current.push(infoWindow);
 
       naver.maps.Event.addListener(marker, 'click', () => {
         if (infoWindow.getMap()) {
@@ -310,7 +312,17 @@ export default function Map({ toilets }: MapProps) {
   const handleClosePanorama = () => setSelectedPanoCoord(null);
 
   // 기존 마커와 클러스터 제거 함수
-  const clearMarkers = () => {
+  const clearMapOverlays = () => {
+    if (toiletInfoWindowsRef) {
+      toiletInfoWindowsRef.current.forEach((toiletInfoWindow) => toiletInfoWindow.close());
+      toiletInfoWindowsRef.current = [];
+    }
+
+    if (geoCoderInfowindowRef.current) {
+      geoCoderInfowindowRef.current.close();
+      geoCoderInfowindowRef.current = null;
+    }
+
     if (markerClusterRef.current) {
       markerClusterRef.current.setMarkers([]);
       markerClusterRef.current.setMap(null);
@@ -360,7 +372,7 @@ export default function Map({ toilets }: MapProps) {
         borderColor: 'transparent',
       });
 
-      clearMarkers();
+      clearMapOverlays();
       setMapCenterCoords({ lat: Number(y), lng: Number(x) });
       mapRef.current.panTo(searchAddressCoordinate);
       geoCoderInfowindow.open(mapRef.current, searchAddressCoordinate);
@@ -410,11 +422,7 @@ export default function Map({ toilets }: MapProps) {
         );
       } else {
         // 주소 검색으로 이동한 좌표와 현재 내 위치 좌표가 동일하지 않을 경우 검색한 주소 주변의 마커를 지운 후 내 위치로 이동
-        if (geoCoderInfowindowRef.current) {
-          geoCoderInfowindowRef.current.close();
-          geoCoderInfowindowRef.current = null;
-        }
-        clearMarkers();
+        clearMapOverlays();
         setMapCenterCoords(currentMyCoordinates);
         mapRef.current.panTo(
           new naver.maps.LatLng(currentMyCoordinates.lat, currentMyCoordinates.lng),
@@ -527,7 +535,7 @@ export default function Map({ toilets }: MapProps) {
             confirmText='전환하기'
             onConfirm={() => {
               if (mapRef.current) {
-                clearMarkers();
+                clearMapOverlays();
                 setMapCenterCoords(currentMyCoordinates || defalutCoordinates);
                 mapRef.current.panTo(currentMyCoordinates || defalutCoordinates);
                 setIsOutsideSeoul(false);

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -91,6 +91,7 @@ export default function Map({ toilets }: MapProps) {
   const mapRef = useRef<naver.maps.Map | null>(null);
   const markerClusterRef = useRef<any>(null);
   const currentLocationMarkerRef = useRef<naver.maps.Marker | null>(null);
+  const geoCoderInfowindowRef = useRef<naver.maps.InfoWindow | null>(null);
   const panoramaRef = useRef<HTMLDivElement | null>(null);
   const addressInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -363,6 +364,7 @@ export default function Map({ toilets }: MapProps) {
       setMapCenterCoords({ lat: Number(y), lng: Number(x) });
       mapRef.current.panTo(searchAddressCoordinate);
       geoCoderInfowindow.open(mapRef.current, searchAddressCoordinate);
+      geoCoderInfowindowRef.current = geoCoderInfowindow;
     });
   };
 
@@ -408,6 +410,10 @@ export default function Map({ toilets }: MapProps) {
         );
       } else {
         // 주소 검색으로 이동한 좌표와 현재 내 위치 좌표가 동일하지 않을 경우 검색한 주소 주변의 마커를 지운 후 내 위치로 이동
+        if (geoCoderInfowindowRef.current) {
+          geoCoderInfowindowRef.current.close();
+          geoCoderInfowindowRef.current = null;
+        }
         clearMarkers();
         setMapCenterCoords(currentMyCoordinates);
         mapRef.current.panTo(

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -86,38 +86,30 @@ export default function Map({ toilets }: MapProps) {
   const [selectedMapType, setSelectedMapType] = useState<MapType>('NORMAL');
   const [selectedPanoCoord, setSelectedPanoCoord] = useState<Coords | null>(null);
   const [isOutsideSeoul, setIsOutsideSeoul] = useState<boolean>(false);
+  const [mapCenterCoords, setMapCenterCoords] = useState<Coords | null>(null);
 
   const mapRef = useRef<naver.maps.Map | null>(null);
+  const markerClusterRef = useRef<any>(null);
   const currentLocationMarkerRef = useRef<naver.maps.Marker | null>(null);
   const panoramaRef = useRef<HTMLDivElement | null>(null);
   const addressInputRef = useRef<HTMLInputElement | null>(null);
 
   const { currentMyCoordinates, geoStatus, getCurPosition } = useGeolocation();
 
-  // const toiletsWithDistance = useMemo(() => {
-  //   if (!currentMyCoordinates) return toilets;
-
-  //   return toilets.map((toilet) => ({
-  //     ...toilet,
-  //     DISTANCE: distanceCalculation(
-  //       currentMyCoordinates.lat,
-  //       currentMyCoordinates.lng,
-  //       toilet.Y_WGS84,
-  //       toilet.X_WGS84,
-  //       'K',
-  //     ),
-  //   }));
-  // }, [toilets, currentMyCoordinates]);
+  // 최초 내 위치(currentMyCoordinates)가 로드되면 mapCenterCoords를 currentMyCoordinates 값으로 변경
+  useEffect(() => {
+    if (currentMyCoordinates && !mapCenterCoords) setMapCenterCoords(currentMyCoordinates);
+  }, [currentMyCoordinates, mapCenterCoords]);
 
   const toiletsWithDistance = useMemo(() => {
-    if (!currentMyCoordinates) return toilets;
+    if (!mapCenterCoords) return toilets;
 
     return toilets
       .map((toilet) => ({
         ...toilet,
         DISTANCE: distanceCalculation(
-          currentMyCoordinates.lat,
-          currentMyCoordinates.lng,
+          mapCenterCoords.lat,
+          mapCenterCoords.lng,
           toilet.Y_WGS84,
           toilet.X_WGS84,
           'K',
@@ -125,22 +117,22 @@ export default function Map({ toilets }: MapProps) {
       }))
       .sort((a, b) => a.DISTANCE - b.DISTANCE)
       .slice(0, 100);
-  }, [toilets, currentMyCoordinates]);
+  }, [toilets, mapCenterCoords]);
 
   // 지도 초기화
   useEffect(() => {
-    if (!currentMyCoordinates || mapRef.current) return;
+    if (!mapCenterCoords || mapRef.current) return;
 
     mapRef.current = new naver.maps.Map('map', {
-      center: new naver.maps.LatLng(currentMyCoordinates.lat, currentMyCoordinates.lng),
+      center: new naver.maps.LatLng(mapCenterCoords.lat, mapCenterCoords.lng),
       zoom: 18,
       minZoom: 8,
       mapDataControl: false,
       disableKineticPan: false,
     });
-  }, [currentMyCoordinates]);
+  }, [mapCenterCoords]);
 
-  // 마커 렌더링 + 클러스터링
+  // 마커 렌더링 및 클러스터링
   useEffect(() => {
     if (!mapRef.current) return;
 
@@ -151,8 +143,8 @@ export default function Map({ toilets }: MapProps) {
       return;
     }
 
-    // 마커와 정보창
     const toiletMarkers: naver.maps.Marker[] = [];
+
     toiletsWithDistance.forEach((toilet) => {
       const { Y_WGS84, X_WGS84, FNAME, ANAME, DISTANCE } = toilet;
 
@@ -185,34 +177,29 @@ export default function Map({ toilets }: MapProps) {
           infoWindow.close();
         } else {
           const coords = new naver.maps.LatLng(Y_WGS84, X_WGS84);
-          naver.maps.Service.reverseGeocode(
-            {
-              coords,
-            },
-            (status, response) => {
-              if (status === naver.maps.Service.Status.OK && mapRef.current) {
-                const { jibunAddress, roadAddress } = response.v2.address;
+          naver.maps.Service.reverseGeocode({ coords }, (status, response) => {
+            if (status === naver.maps.Service.Status.OK && mapRef.current) {
+              const { jibunAddress, roadAddress } = response.v2.address;
 
-                flushSync(() =>
-                  root.render(
-                    <MarkerInfoWindow
-                      FNAME={FNAME}
-                      ANAME={ANAME}
-                      jibunAddress={jibunAddress}
-                      roadAddress={roadAddress}
-                      DISTANCE={DISTANCE}
-                      onClickPanorama={() => {
-                        handleOpenPanorama(Y_WGS84, X_WGS84);
-                        if (mapRef.current) mapRef.current.panTo(coords);
-                      }}
-                    />,
-                  ),
-                );
+              flushSync(() =>
+                root.render(
+                  <MarkerInfoWindow
+                    FNAME={FNAME}
+                    ANAME={ANAME}
+                    jibunAddress={jibunAddress}
+                    roadAddress={roadAddress}
+                    DISTANCE={DISTANCE}
+                    onClickPanorama={() => {
+                      handleOpenPanorama(Y_WGS84, X_WGS84);
+                      if (mapRef.current) mapRef.current.panTo(coords);
+                    }}
+                  />,
+                ),
+              );
 
-                infoWindow.open(mapRef.current, marker);
-              }
-            },
-          );
+              infoWindow.open(mapRef.current, marker);
+            }
+          });
         }
       });
     });
@@ -239,7 +226,7 @@ export default function Map({ toilets }: MapProps) {
       anchor: new naver.maps.Point(12, 12),
     };
 
-    new MarkerClustering({
+    markerClusterRef.current = new MarkerClustering({
       map: mapRef.current,
       markers: toiletMarkers,
       disableClickZoom: false,
@@ -262,22 +249,23 @@ export default function Map({ toilets }: MapProps) {
     });
   }, [toiletsWithDistance]);
 
+  // mapCenterCoords가 서울 밖에 있는지 체크
   useEffect(() => {
-    if (!currentMyCoordinates) return;
+    if (!mapCenterCoords) return;
 
-    // 현재 좌표가 서울 경계 밖에 있는지 체크
     if (
-      currentMyCoordinates.lat > seoulBoundaryCoordinates.north ||
-      currentMyCoordinates.lat < seoulBoundaryCoordinates.south ||
-      currentMyCoordinates.lng < seoulBoundaryCoordinates.west ||
-      currentMyCoordinates.lng > seoulBoundaryCoordinates.east
+      mapCenterCoords.lat > seoulBoundaryCoordinates.north ||
+      mapCenterCoords.lat < seoulBoundaryCoordinates.south ||
+      mapCenterCoords.lng < seoulBoundaryCoordinates.west ||
+      mapCenterCoords.lng > seoulBoundaryCoordinates.east
     ) {
       setIsOutsideSeoul(true);
     } else {
       setIsOutsideSeoul(false);
     }
-  }, [currentMyCoordinates]);
+  }, [mapCenterCoords]);
 
+  // 현재 위치 마커 업데이트
   useEffect(() => {
     if (geoStatus === 'error') {
       toast.error(
@@ -301,9 +289,7 @@ export default function Map({ toilets }: MapProps) {
         anchor: new naver.maps.Point(12, 12),
       },
     });
-
-    mapRef.current.panTo(new naver.maps.LatLng(currentMyCoordinates.lat, currentMyCoordinates.lng));
-  }, [currentMyCoordinates, geoStatus]);
+  }, [currentMyCoordinates, geoStatus, mapCenterCoords]);
 
   // 파노라마
   useEffect(() => {
@@ -320,20 +306,29 @@ export default function Map({ toilets }: MapProps) {
   }, [selectedPanoCoord]);
 
   const handleOpenPanorama = (lat: number, lng: number) => setSelectedPanoCoord({ lat, lng });
-
   const handleClosePanorama = () => setSelectedPanoCoord(null);
 
-  // 주소 -> 좌표 검색
+  // 기존 마커와 클러스터 제거 함수
+  const clearMarkers = () => {
+    if (markerClusterRef.current) {
+      markerClusterRef.current.setMarkers([]);
+      markerClusterRef.current.setMap(null);
+      markerClusterRef.current = null;
+    }
+  };
+
+  // 주소 검색
   const searchAddressToCoordinate = (searchAddress: string) => {
     const trimmedSearchAddress = searchAddress.trim();
-
     if (!trimmedSearchAddress) return;
 
     naver.maps.Service.geocode({ query: trimmedSearchAddress }, (status, response) => {
       if (!mapRef.current) return;
 
       if (status === naver.maps.Service.Status.ERROR) {
-        toast.error('주소 검색 중 문제가 발생했어요.');
+        toast.error('주소 검색 중 문제가 발생했어요.', {
+          icon: <IoIosAlert className='text-blue-500' size={20} />,
+        });
         return;
       }
 
@@ -364,7 +359,8 @@ export default function Map({ toilets }: MapProps) {
         borderColor: 'transparent',
       });
 
-      // 검색한 주소의 위치로 지도 중심 이동 및 InfoWindow 오픈
+      clearMarkers();
+      setMapCenterCoords({ lat: Number(y), lng: Number(x) });
       mapRef.current.panTo(searchAddressCoordinate);
       geoCoderInfowindow.open(mapRef.current, searchAddressCoordinate);
     });
@@ -397,6 +393,30 @@ export default function Map({ toilets }: MapProps) {
     }
   };
 
+  const handleCurrentLocation = () => {
+    getCurPosition();
+
+    if (currentMyCoordinates && mapRef.current) {
+      if (
+        mapCenterCoords &&
+        mapCenterCoords.lat === currentMyCoordinates.lat &&
+        mapCenterCoords.lng === currentMyCoordinates.lng
+      ) {
+        // 현재 지도 중심이 내 위치일 때 현재 위치 버튼을 클릭할 경우 지도 중심만 내 위치로 이동
+        mapRef.current.panTo(
+          new naver.maps.LatLng(currentMyCoordinates.lat, currentMyCoordinates.lng),
+        );
+      } else {
+        // 주소 검색으로 이동한 좌표와 현재 내 위치 좌표가 동일하지 않을 경우 검색한 주소 주변의 마커를 지운 후 내 위치로 이동
+        clearMarkers();
+        setMapCenterCoords(currentMyCoordinates);
+        mapRef.current.panTo(
+          new naver.maps.LatLng(currentMyCoordinates.lat, currentMyCoordinates.lng),
+        );
+      }
+    }
+  };
+
   return (
     <>
       {!currentMyCoordinates ? (
@@ -409,8 +429,11 @@ export default function Map({ toilets }: MapProps) {
                 save <span className='font-semibold'>me</span>
               </div>
               <div className='relative w-[calc(100%-24px)]'>
-                <button className='absolute left-2 top-1/2 -translate-y-1/2 transform'>
-                  <IoSearch className='h-7 w-7 text-blue-500' onClick={handleSearchClick} />
+                <button
+                  className='absolute left-2 top-1/2 -translate-y-1/2 transform'
+                  onClick={handleSearchClick}
+                >
+                  <IoSearch className='h-7 w-7 text-blue-500' />
                 </button>
                 <input
                   className='h-11 w-full rounded-md pl-10 font-medium shadow-md focus:outline-none sm:w-[370px] sm:rounded-l-none sm:rounded-br-md sm:rounded-tr-md'
@@ -452,7 +475,7 @@ export default function Map({ toilets }: MapProps) {
             <div className='absolute bottom-11 right-3 z-10'>
               <button
                 className='group mb-3 flex h-9 w-9 items-center justify-center rounded-md border border-gray-300 bg-white shadow-md outline-white'
-                onClick={getCurPosition}
+                onClick={handleCurrentLocation}
                 disabled={geoStatus === 'loading'}
               >
                 <IoMdLocate className='locateIcon text-gray-700' size={21} />
@@ -498,7 +521,9 @@ export default function Map({ toilets }: MapProps) {
             confirmText='전환하기'
             onConfirm={() => {
               if (mapRef.current) {
-                mapRef.current.panTo(defalutCoordinates);
+                clearMarkers();
+                setMapCenterCoords(currentMyCoordinates || defalutCoordinates);
+                mapRef.current.panTo(currentMyCoordinates || defalutCoordinates);
                 setIsOutsideSeoul(false);
               }
             }}

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -103,7 +103,7 @@ export default function Map({ toilets }: MapProps) {
   }, [currentMyCoordinates, mapCenterCoords]);
 
   const toiletsWithDistance = useMemo(() => {
-    if (!mapCenterCoords) return toilets;
+    if (!mapCenterCoords) return [];
 
     return toilets
       .map((toilet) => ({
@@ -135,7 +135,7 @@ export default function Map({ toilets }: MapProps) {
 
   // 마커 렌더링 및 클러스터링
   useEffect(() => {
-    if (!mapRef.current) return;
+    if (!mapRef.current || geoStatus === 'error') return;
 
     if (!toiletsWithDistance.length) {
       toast.error('화장실 데이터를 불러오는데 실패했습니다. 잠시 후 다시 시도해 주세요.', {

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -85,8 +85,9 @@ const seoulBoundaryCoordinates = {
 export default function Map({ toilets }: MapProps) {
   const [selectedMapType, setSelectedMapType] = useState<MapType>('NORMAL');
   const [selectedPanoCoord, setSelectedPanoCoord] = useState<Coords | null>(null);
-  const [isOutsideSeoul, setIsOutsideSeoul] = useState<boolean>(false);
   const [mapCenterCoords, setMapCenterCoords] = useState<Coords | null>(null);
+  const [isOutsideSeoul, setIsOutsideSeoul] = useState<boolean>(false);
+  const [isSearchAddress, setIsSearchAddress] = useState<boolean>(false);
 
   const mapRef = useRef<naver.maps.Map | null>(null);
   const currentLocationMarkerRef = useRef<naver.maps.Marker | null>(null);
@@ -192,6 +193,7 @@ export default function Map({ toilets }: MapProps) {
                     jibunAddress={jibunAddress}
                     roadAddress={roadAddress}
                     DISTANCE={DISTANCE}
+                    isSearchAddress={isSearchAddress}
                     onClickPanorama={() => {
                       handleOpenPanorama(Y_WGS84, X_WGS84);
                       if (mapRef.current) mapRef.current.panTo(coords);
@@ -372,9 +374,12 @@ export default function Map({ toilets }: MapProps) {
         borderColor: 'transparent',
       });
 
+      setIsSearchAddress(true);
+
       clearMapOverlays();
       setMapCenterCoords({ lat: Number(y), lng: Number(x) });
       mapRef.current.panTo(searchAddressCoordinate);
+
       geoCoderInfowindow.open(mapRef.current, searchAddressCoordinate);
       geoCoderInfowindowRef.current = geoCoderInfowindow;
     });
@@ -409,6 +414,7 @@ export default function Map({ toilets }: MapProps) {
 
   const handleCurrentLocation = () => {
     getCurPosition();
+    setIsSearchAddress(false);
 
     if (currentMyCoordinates && mapRef.current) {
       if (

--- a/src/components/Markers.tsx
+++ b/src/components/Markers.tsx
@@ -6,6 +6,7 @@ interface MarkerInfoWindowProps {
   jibunAddress: string;
   roadAddress: string;
   DISTANCE: number;
+  isSearchAddress: boolean;
   onClickPanorama: () => void;
 }
 
@@ -30,6 +31,7 @@ export function MarkerInfoWindow({
   jibunAddress,
   roadAddress,
   DISTANCE,
+  isSearchAddress,
   onClickPanorama,
 }: MarkerInfoWindowProps) {
   return (
@@ -58,7 +60,7 @@ export function MarkerInfoWindow({
       </div>
       <div className='flex items-center justify-between gap-x-4'>
         <div className='text-sm font-medium'>
-          현재 위치로부터 약{' '}
+          {isSearchAddress ? '검색한 주소로부터 약 ' : '현재 위치로부터 약 '}
           <span className='font-bold'>
             {DISTANCE < 1 ? `${Math.round(DISTANCE * 1000)}m` : `${Number(DISTANCE.toFixed(1))}km`}
           </span>

--- a/src/components/Markers.tsx
+++ b/src/components/Markers.tsx
@@ -39,12 +39,14 @@ export function MarkerInfoWindow({
         <p className='text-sm font-medium text-gray-500'>{ANAME}</p>
       </div>
       <div className='flex flex-col gap-y-1'>
-        <div className='text-sm font-medium'>
-          <span className='mr-1.5 rounded border border-gray-400 px-1 py-0.5 text-xs font-semibold text-gray-700'>
-            도로명
-          </span>
-          {roadAddress}서울특별시 중구 명동
-        </div>
+        {roadAddress && (
+          <div className='text-sm font-medium'>
+            <span className='mr-1.5 rounded border border-gray-400 px-1 py-0.5 text-xs font-semibold text-gray-700'>
+              도로명
+            </span>
+            {roadAddress}
+          </div>
+        )}
         {jibunAddress && (
           <div className='text-sm font-medium'>
             <span className='mr-1.5 rounded border border-gray-400 px-1 py-0.5 text-xs font-semibold text-gray-700'>
@@ -56,11 +58,14 @@ export function MarkerInfoWindow({
       </div>
       <div className='flex items-center justify-between gap-x-4'>
         <div className='text-sm font-medium'>
-          현재 위치로부터 약 <span className='font-bold'>{DISTANCE}m</span>
+          현재 위치로부터 약{' '}
+          <span className='font-bold'>
+            {DISTANCE < 1 ? `${Math.round(DISTANCE * 1000)}m` : `${Number(DISTANCE.toFixed(1))}km`}
+          </span>
         </div>
         <div className='flex justify-end'>
           <button
-            className='mt-1 flex rounded-full border border-gray-300 p-1.5 text-gray-600 hover:border-blue-500 hover:text-blue-500'
+            className='flex rounded-full border border-gray-300 p-1.5 text-gray-600 hover:border-blue-500 hover:text-blue-500'
             onClick={onClickPanorama}
           >
             <FiMapPin className='h-5 w-5' />

--- a/src/components/Markers.tsx
+++ b/src/components/Markers.tsx
@@ -5,6 +5,7 @@ interface MarkerInfoWindowProps {
   ANAME: string;
   jibunAddress: string;
   roadAddress: string;
+  DISTANCE: number;
   onClickPanorama: () => void;
 }
 
@@ -28,6 +29,7 @@ export function MarkerInfoWindow({
   ANAME,
   jibunAddress,
   roadAddress,
+  DISTANCE,
   onClickPanorama,
 }: MarkerInfoWindowProps) {
   return (
@@ -36,22 +38,34 @@ export function MarkerInfoWindow({
         <p className='text-lg font-bold'>{FNAME}</p>
         <p className='text-sm font-medium text-gray-500'>{ANAME}</p>
       </div>
-      {roadAddress && <div>(도로명) {roadAddress}</div>}
-      {jibunAddress && (
+      <div className='flex flex-col gap-y-1'>
         <div className='text-sm font-medium'>
           <span className='mr-1.5 rounded border border-gray-400 px-1 py-0.5 text-xs font-semibold text-gray-700'>
-            지번
+            도로명
           </span>
-          {jibunAddress}
+          {roadAddress}서울특별시 중구 명동
         </div>
-      )}
-      <div className='flex justify-end'>
-        <button
-          className='mt-1 flex rounded-full border border-gray-300 p-1.5 text-gray-600 hover:border-blue-500 hover:text-blue-500'
-          onClick={onClickPanorama}
-        >
-          <FiMapPin className='h-5 w-5' />
-        </button>
+        {jibunAddress && (
+          <div className='text-sm font-medium'>
+            <span className='mr-1.5 rounded border border-gray-400 px-1 py-0.5 text-xs font-semibold text-gray-700'>
+              지번
+            </span>
+            {jibunAddress}
+          </div>
+        )}
+      </div>
+      <div className='flex items-center justify-between gap-x-4'>
+        <div className='text-sm font-medium'>
+          현재 위치로부터 약 <span className='font-bold'>{DISTANCE}m</span>
+        </div>
+        <div className='flex justify-end'>
+          <button
+            className='mt-1 flex rounded-full border border-gray-300 p-1.5 text-gray-600 hover:border-blue-500 hover:text-blue-500'
+            onClick={onClickPanorama}
+          >
+            <FiMapPin className='h-5 w-5' />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -23,10 +23,6 @@ export const useGeolocation = () => {
         lat: location.coords.latitude,
         lng: location.coords.longitude,
       };
-      // const newCoords = {
-      //   lat: defalutCoordinates.lat,
-      //   lng: defalutCoordinates.lng,
-      // };
       setCurrentMyCoordinates(newCoords);
       setGeoStatus('success');
     };

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -23,6 +23,10 @@ export const useGeolocation = () => {
         lat: location.coords.latitude,
         lng: location.coords.longitude,
       };
+      // const newCoords = {
+      //   lat: defalutCoordinates.lat,
+      //   lng: defalutCoordinates.lng,
+      // };
       setCurrentMyCoordinates(newCoords);
       setGeoStatus('success');
     };

--- a/src/util/helpers/distanceCalculation.ts
+++ b/src/util/helpers/distanceCalculation.ts
@@ -12,21 +12,21 @@ export const distanceCalculation = (
     const radlat2 = (Math.PI * dataLat) / 180;
     const theta = myLng - dataLng;
     const radtheta = (Math.PI * theta) / 180;
+
     let dist =
       Math.sin(radlat1) * Math.sin(radlat2) +
       Math.cos(radlat1) * Math.cos(radlat2) * Math.cos(radtheta);
-    if (dist > 1) {
-      dist = 1;
-    }
+
+    if (dist > 1) dist = 1;
+
     dist = Math.acos(dist);
     dist = (dist * 180) / Math.PI;
     dist = dist * 60 * 1.1515;
-    if (unit === 'K') {
-      dist = dist * 1.609344;
-    }
-    if (unit === 'N') {
-      dist = dist * 0.8684;
-    }
+
+    if (unit === 'K') dist = dist * 1.609344;
+
+    if (unit === 'N') dist = dist * 0.8684;
+
     return dist;
   }
 };

--- a/src/util/helpers/distanceCalculation.ts
+++ b/src/util/helpers/distanceCalculation.ts
@@ -25,8 +25,6 @@ export const distanceCalculation = (
 
     if (unit === 'K') dist = dist * 1.609344;
 
-    if (unit === 'N') dist = dist * 0.8684;
-
     return dist;
   }
 };


### PR DESCRIPTION
## Related issue
- [#27 현재 사용자의 위치에서 화장실이 얼마나 떨어져 있는지 거리 표시](https://github.com/kimdonggu42/saveme/issues/27)

## Result
![Mar-18-2025 18-58-53](https://github.com/user-attachments/assets/4b18fc72-a988-47b6-82b3-c12dc818e91c)

<img width="100%" alt="스크린샷 2025-03-18 오후 2 17 00" src="https://github.com/user-attachments/assets/ce34928c-6e48-4b06-87df-91e2efe4a716" />

## Work list
- 화장실 정보창에 현재 위치 또는 검색한 주소에서부터 각 화장실까지의 거리를 표시하도록 기능 추가
- 주소 검색 또는 현재 위치 버튼 클릭 시, 기존에 지도에 표시된 마커와 정보창을 모두 초기화한 후, 새롭게 이동한 좌표 주변의 마커와 정보창을 렌더링하도록 수정
- 네이버 지도 API 스크립트 로딩 시, 누락된 beforeInteractive 옵션 추가
- 에러 페이지 추가
- Geolocation API를 통해 현재 위치 접근이 불가능한 경우, 기본 좌표(defaultCoordinates) 주변의 화장실 마커가 렌더링되지 않도록 처리
- 서울 외 지역의 주소를 검색했을 때에도 알림 모달이 표시되도록 수정

## Discussion